### PR TITLE
Add corSparse Internally (qlcMatrix archived from CRAN)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
 URL: https://smorabit.github.io/hdWGCNA/
-Imports: WGCNA, Seurat, Matrix, harmony, igraph, ggplot2, dplyr, tester, qlcMatrix
+Imports: WGCNA, Seurat, Matrix, harmony, igraph, ggplot2, dplyr, tester
 Suggests: testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Depends: 

--- a/R/ModuleConnectivity.R
+++ b/R/ModuleConnectivity.R
@@ -82,11 +82,8 @@ ModuleConnectivity <- function(
   )[genes_use,cells.use]
 
   if(sparse){
-    if(!('qlcMatrix' %in% installed.packages())){
-      stop('Need to install package qlcMatrix if sparse=TRUE. Either set sparse=FALSE or install qlcMatrix package.')
-    }
     
-    kMEs <- qlcMatrix::corSparse(
+    kMEs <- corSparse(
       X = Matrix::t(exp_mat),
       Y = as.matrix(MEs)
     )

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -61,7 +61,7 @@ shuffle_points <- function(df){
 #' 
 #' Originally from 
 #' \url{http://stackoverflow.com/questions/5888287/running-cor-or-any-variant-over-a-sparse-matrix-in-r}
-#' and the qlcMatrix package.
+#' and the qlcMatrix & Signac packages.
 #' 
 #' @param X A matrix
 #' @param Y A matrix

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -52,3 +52,55 @@ umap_theme <- function(){
 shuffle_points <- function(df){
   return(df[sample(1:dim(df)[1], dim(df)[1]),])
 }
+
+
+#' Sparse matrix correlation
+#' 
+#' Compute the Pearson correlation matrix between
+#' columns of two sparse matrices.
+#' 
+#' Originally from 
+#' \url{http://stackoverflow.com/questions/5888287/running-cor-or-any-variant-over-a-sparse-matrix-in-r}
+#' and the qlcMatrix package.
+#' 
+#' @param X A matrix
+#' @param Y A matrix
+#' @param cov return covariance matrix
+#' @export
+#' @author Michael Cysouw, Karsten Looschen
+#' @importMethodsFrom Matrix colMeans
+# covmat uses E[(X-muX)'(Y-muY)] = E[X'Y] - muX'muY
+# with sample correction n/(n-1) this leads to cov = ( X'Y - n*muX'muY ) / (n-1)
+#
+# the sd in the case Y!=NULL uses E[X-mu]^2 = E[X^2]-mu^2
+# with sample correction n/(n-1) this leads to sd^2 = ( X^2 - n*mu^2 ) / (n-1)
+#
+# Note that results larger than 1e4 x 1e4 will become very slow, because the resulting matrix is not sparse anymore.
+corSparse <- function(X, Y = NULL, cov = FALSE) {
+  X <- as(object = X, Class = "CsparseMatrix")
+  n <- nrow(x = X)
+  muX <- colMeans(x = X)
+
+  if (!is.null(x = Y)) {
+    if (nrow(x = X) != nrow(x = Y)) {
+      stop("Matrices must contain the same number of rows")
+    }
+    Y <- as(object = Y, Class = "CsparseMatrix")
+    muY <- colMeans(x = Y)
+    covmat <- ( as.matrix(x = crossprod(x = X, y = Y)) - n * tcrossprod(x = muX, y = muY) ) / (n-1)
+    sdvecX <- sqrt( (colSums(x = X^2) - n*muX^2) / (n-1) )
+    sdvecY <- sqrt( (colSums(x = Y^2) - n*muY^2) / (n-1) )
+    cormat <- covmat / tcrossprod(x = sdvecX, y = sdvecY)
+  } else {		
+    covmat <- ( as.matrix(crossprod(x = X)) - n * tcrossprod(x = muX) ) / (n-1)
+    sdvec <- sqrt(x = diag(x = covmat))
+    cormat <- covmat / tcrossprod(x = sdvec)
+  }
+  if (cov) {
+    dimnames(x = covmat) <- NULL
+    return(covmat)
+  } else {
+    dimnames(x = cormat) <- NULL
+    return(cormat)
+  }
+}


### PR DESCRIPTION
Hi Sam/Swarup Lab,

Quick PR here to overcome recent archiving of qlcMatrix package from CRAN.  Given that the package hasn't been updated in 5+ years and has been archived for 1.5 months it appears to be abandoned.  This prevents hdWGCNA installation as it's listed in Imports.  This can be solved by installing from source from CRAN archive but that's not obvious solution for many.

This recently came up as issue for Signac package (https://github.com/stuart-lab/signac/issues/1570) and they decided to simply implement function internally (https://github.com/stuart-lab/signac/commit/ba9cf7eae3ffc1285e912926ec953e6e01963736) with reference to original stackoverflow post and qlcMatrix package (which did not have any license listed).

This PR simply implements the function the same as Signac did (and now also references Signac's implementation.

Best,
Sam