### PR TITLE
Adjusted ComputeModuleEigengenes

### DIFF
--- a/R/ModuleEigengenes.R
+++ b/R/ModuleEigengenes.R
@@ -84,7 +84,9 @@ ComputeModuleEigengene <- function(
     cur_seurat,
     features = cur_genes,
     reduction.key=paste0('pca', cur_mod),
-    verbose=verbose, ...
+    verbose=verbose, 
+    npcs = pc_dim,
+    ...
   )@reductions$pca
   pc <- cur_pca@cell.embeddings[,pc_dim]
   pc_loadings <- cur_pca@feature.loadings[,pc_dim]


### PR DESCRIPTION
Adjusted Compute Module Eigengenes to allow for fewer pcs to be calculated for small datasets. set npcs = pc_dim