### PR TITLE
Fixed ModuleExprScore and ModuleRadarPlot Error with single modules and MEs in ModuleRadarPlot always defaulting to active wgcna even if a wgcna_name is provided

### DIFF
--- a/R/ModuleEigengenes.R
+++ b/R/ModuleEigengenes.R
@@ -358,6 +358,11 @@ ModuleExprScore <- function(
 
   mod_scores <- mod_scores[,(ncol(mod_scores)-length(mods)+1):ncol(mod_scores)]
 
+  # When there's only 1 module mod_scores becomes an array instead of data.frame and causes Error during colnames
+  if (!is.data.frame(mod_scores)) {
+    mod_scores <- as.data.frame(mod_scores)
+  }
+  
   # rename module scores:
   colnames(mod_scores) <- mods
 

--- a/R/ModuleEigengenes.R
+++ b/R/ModuleEigengenes.R
@@ -356,13 +356,8 @@ ModuleExprScore <- function(
     stop("Invalid method selection. Valid choices are Seurat, UCell")
   }
 
-  mod_scores <- mod_scores[,(ncol(mod_scores)-length(mods)+1):ncol(mod_scores)]
+  mod_scores <- mod_scores[,(ncol(mod_scores)-length(mods)+1):ncol(mod_scores), drop = FALSE]
 
-  # When there's only 1 module mod_scores becomes an array instead of data.frame and causes Error during colnames
-  if (!is.data.frame(mod_scores)) {
-    mod_scores <- as.data.frame(mod_scores)
-  }
-  
   # rename module scores:
   colnames(mod_scores) <- mods
 

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -3010,7 +3010,7 @@ ModuleRadarPlot <- function(
   mods <- levels(modules$module); mods <- mods[mods != 'grey']
 
   # get the MEs
-  MEs <- GetMEs(seurat_obj)
+  MEs <- GetMEs(seurat_obj, wgcna_name = wgcna_name)
   MEs <- MEs[,colnames(MEs) != 'grey', drop = FALSE]
 
   # are we subsetting?

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -3011,7 +3011,7 @@ ModuleRadarPlot <- function(
 
   # get the MEs
   MEs <- GetMEs(seurat_obj)
-  MEs <- MEs[,colnames(MEs) != 'grey']
+  MEs <- MEs[,colnames(MEs) != 'grey', drop = FALSE]
 
   # are we subsetting?
   if(!is.null(barcodes)){

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -3020,7 +3020,7 @@ ModuleRadarPlot <- function(
     }
 
     # subset:
-    MEs <- MEs[barcodes,]
+    MEs <- MEs[barcodes, , drop = FALSE]
     meta <- meta[barcodes,]
     cell_grouping <- cell_grouping[barcodes]
   }


### PR DESCRIPTION
When there's only 1 module mod_scores becomes an array instead of data.frame and causes:
Error: <simpleError in `colnames<-`(`*tmp*`, value = mods): attempt to set 'colnames' on an object with less than two dimensions> during colnames 
Added code so that if mod_scores is not data.frame change it to data.frame