### PR TITLE
Update ConstructNetwork.R

### DIFF
--- a/R/ConstructNetwork.R
+++ b/R/ConstructNetwork.R
@@ -164,7 +164,9 @@ ConstructNetwork <- function(
   seurat_obj <- SetWGCNAParams(seurat_obj, params, wgcna_name)
 
   # append working directory to the TOM file so it has the full path:
-  net$TOMFiles <- paste0(getwd(), '/', renamed)
+  net$TOMFiles <- ifelse(test = substr(renamed,1,1) == "/", 
+                         yes = renamed, 
+                         no = paste0(getwd(), '/', renamed))
 
   # add network to seurat obj
   seurat_obj <- SetNetworkData(seurat_obj, net, wgcna_name)


### PR DESCRIPTION
Add the possibility to use an absolute path for unix-based systems. To handle other OS, you would have to use xfun or R.utils.